### PR TITLE
Fix a bug related to custom themes

### DIFF
--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -33,7 +33,7 @@ var friction := 0.9
 func _ready() -> void:
 	get_v_scrollbar().connect("scrolling", self, "_on_VScrollBar_scrolling")
 	for c in get_children():
-		content_node = c
+		if not c is ScrollBar: content_node = c
 
 
 func _process(delta: float) -> void:


### PR DESCRIPTION
For some reason, when a custom theme is applied to the SmoothScrollContainer or one of it's parents, the content_node variable is set to VScrollBar or HScrollBar, making the code not work. I fixed it by eliminating those options when setting the content_node variable