### PR TITLE
Fix overdrag bounce problem and follow focus

### DIFF
--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -33,10 +33,6 @@ var friction_drag := 0.9
 var velocity := Vector2(0,0)
 # Below this value, velocity is set to `0`
 var just_stop_under := 0.01
-# Current counterforce for "overdragging" on the top
-var over_drag_multiplicator_top := 1
-# Current counterforce for "overdragging" on the bottom
-var over_drag_multiplicator_bottom := 1
 # Control node to move when scrolling
 var content_node : Control
 # Current position of `content_node`
@@ -74,18 +70,6 @@ func _process(delta: float) -> void:
 	# How long it will take to stop scrolling
 	var stop_frame = log(just_stop_under/abs(velocity.y+0.001))/log(friction*0.999)
 	stop_frame = floor(max(stop_frame, 0.0))
-	
-	# If overdragged on bottom:
-	if bottom_distance < 0:
-		over_drag_multiplicator_bottom = 1/abs(bottom_distance)*10
-	else:
-		over_drag_multiplicator_bottom = 1
-	
-	# If overdragged on top:
-	if top_distance > 0:
-		over_drag_multiplicator_top = 1/abs(top_distance)*10
-	else:
-		over_drag_multiplicator_top = 1
 	
 	# If velocity is too low, just set it to 0
 	if velocity.length() <= just_stop_under:

--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -95,7 +95,7 @@ func _process(delta: float) -> void:
 		if bottom_distance < 0:
 			if velocity.y >= 0:
 				# Calculate dist
-				for i in stop_frame:
+				for i in stop_frame+1:
 					stop_distance += abs(vel_y)
 					vel_y *= friction
 					dist = stop_distance - abs(bottom_distance)
@@ -113,7 +113,7 @@ func _process(delta: float) -> void:
 		if top_distance > 0:
 			if velocity.y <= 0:
 				# Calculate dist
-				for i in stop_frame:
+				for i in stop_frame+1:
 					stop_distance += abs(vel_y)
 					vel_y *= friction
 					dist = stop_distance - abs(top_distance)

--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -193,18 +193,13 @@ func _on_focus_changed(control: Control) -> void:
 		return
 	
 	var focus_size = control.size.y
-	var focus_top = control.position.y
+	var focus_top = control.global_position.y - self.global_position.y
 	
-	var scroll_size = size.y
-	var scroll_top = get_v_scroll()
-	var scroll_bottom = scroll_top + scroll_size - focus_size
+	if focus_top < 0.0:
+		scroll_to(content_node.position.y - focus_top)
 	
-	if focus_top < scroll_top:
-		scroll_to(focus_top)
-	
-	if focus_top > scroll_bottom:
-		var scroll_offset = scroll_top + focus_top - scroll_bottom
-		scroll_to(scroll_offset)
+	if focus_top + focus_size > self.size.y:
+		scroll_to(content_node.position.y - focus_top - focus_size + self.size.y)
 
 func _on_VScrollBar_scrolling() -> void:
 	scrollbar_dragging = true
@@ -214,7 +209,9 @@ func _on_HScrollBar_scrolling() -> void:
 
 # Scrolls to specific position
 func scroll_to(y_pos: float) -> void:
-	velocity.y = -(y_pos + content_node.position.y) / 8
+	velocity.y = 0.0
+	var tween = create_tween()
+	tween.tween_property(self, "pos:y", y_pos, 0.5).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_QUINT)
 
 # Scrolls up a page
 func scroll_page_up() -> void:

--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -12,7 +12,7 @@ var speed := 5.0
 var damping_scroll := 0.1
 # Softness of damping when "overdragging" with dragging
 @export_range(0, 1)
-var damping_drag := 0.3
+var damping_drag := 0.1
 # Scrolls to currently focused child element
 @export
 var follow_focus_ := true
@@ -27,7 +27,7 @@ var allow_horizontal_scroll := true
 var friction_scroll := 0.9
 # Friction when using touch
 @export_range(0, 1)
-var friction_drag := 0.97
+var friction_drag := 0.9
 
 # Current velocity of the `content_node`
 var velocity := Vector2(0,0)

--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -88,10 +88,11 @@ func _process(delta: float) -> void:
 	
 	# Applies counterforces when overdragging
 	if not content_dragging:
+		var stop_distance = 0.0 # Distance it takes to stop
+		var dist = 0.0 # To see whether it is over bounce
+		var vel_y = velocity.y # Store velocity.y
+	
 		if bottom_distance < 0:
-			var stop_distance = 0.0 # Distance it takes to stop
-			var dist = 0.0 # To see whether it is over bounce
-			var vel_y = velocity.y # Store velocity.y
 			if velocity.y >= 0:
 				# Calculate dist
 				for i in stop_frame:
@@ -110,9 +111,6 @@ func _process(delta: float) -> void:
 			elif bounce: velocity.y = (friction-1) * bottom_distance
 		
 		if top_distance > 0:
-			var stop_distance = 0.0 # Distance it takes to stop
-			var dist = 0.0 # To see whether it is over bounce
-			var vel_y = velocity.y # Store velocity.y
 			if velocity.y <= 0:
 				# Calculate dist
 				for i in stop_frame:

--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -7,9 +7,12 @@ extends ScrollContainer
 # Drag impact for one scroll input
 @export_range(0, 10, 0.01, "or_greater")
 var speed := 5.0
-# Softness of damping when "overdragging"
+# Softness of damping when "overdragging" with wheel button
 @export_range(0, 1)
-var damping := 0.1
+var damping_scroll := 0.1
+# Softness of damping when "overdragging" with dragging
+@export_range(0, 1)
+var damping_drag := 0.3
 # Scrolls to currently focused child element
 @export
 var follow_focus_ := true
@@ -46,6 +49,8 @@ var friction := 0.9
 var content_dragging = false
 # If it bounce last frame
 var bounce = true
+# Damping to use
+var damping = 0.1
 
 
 func _ready() -> void:
@@ -163,7 +168,9 @@ func _gui_input(event: InputEvent) -> void:
 					bounce = false
 			_:                  scrolled = false
 			
-		if scrolled: friction = friction_scroll
+		if scrolled: 
+			friction = friction_scroll
+			damping = damping_scroll
 	
 	if event is InputEventScreenDrag:
 		if content_dragging:
@@ -177,6 +184,7 @@ func _gui_input(event: InputEvent) -> void:
 			content_dragging = false
 			friction = friction_drag
 			bounce = false
+			damping = damping_drag
 	# Handle input
 	get_tree().get_root().set_input_as_handled()
 

--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -5,8 +5,8 @@
 extends ScrollContainer
 
 # Drag impact for one scroll input
-@export_range(1, 10)
-var speed := 2
+@export_range(0, 10, 0.01, "or_greater")
+var speed := 5.0
 # Softness of damping when "overdragging"
 @export_range(0, 1)
 var damping := 0.1

--- a/example.tscn
+++ b/example.tscn
@@ -28,8 +28,11 @@ offset_bottom = 393.0
 script = ExtResource("1_su8ig")
 
 [node name="Control" type="Control" parent="SmoothScrollContainer"]
-custom_minimum_size = Vector2(0, 943)
+custom_minimum_size = Vector2i(0, 943)
 layout_mode = 2
+anchors_preset = 0
+offset_right = 382.0
+offset_bottom = 943.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 


### PR DESCRIPTION
Over dragging with high speed would make it bounce back too much, not like touch screen app.
I managed to use an inelegant way to bounce back to boundary.

Also, I found the #2 solution is to set_input_as_handled() to avoid the original scroll container receiving input event.
I guess it is because the original scroll container does not allow content moving outside, it tries to pull it back when receiving input event. Not sure it is a glitch of Godot or not. But set_input_as_handled() makes it loses the ability to pass input event, maybe there is a better solution.

To avoid over drag too much, I add an exported an Enum that allows users to set up over drag zone.

Following focus now is more accurate, due to scroll_to(y_pos) uses tween now.