### PR TITLE
Add full support of horizontal scrolling

### DIFF
--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -92,45 +92,18 @@ func scroll_x():
 	
 	# Applies counterforces when overdragging
 	if not content_dragging:
-		var stop_distance = 0.0 # Distance it takes to stop
-		var dist_x = 0.0 # To see whether it is over bounce
-		var vel_x = velocity.x # Store velocity.x
-	
+		
 		if right_distance < 0:
-			if velocity.x >= 0:
-				# Calculate dist
-				for i in stop_frame+1:
-					stop_distance += abs(vel_x)
-					vel_x *= friction
-					dist_x = stop_distance - abs(right_distance)
-					if dist_x > 0.0: break
-				# Just snap to the boundary if close enough
-				if abs(right_distance) < 0.4:
-					velocity.x = 0.0
-					pos.x = self.size.x - content_node.size.x
-			# How it bounce
-			if velocity.x <= 0 or dist_x < 0.0 :
-				velocity.x = lerp(velocity.x, -right_distance/8, damping)
-				bounce_x = true
-			elif bounce_x: velocity.x = (friction-1) * right_distance
+			var a = over_bounce(-velocity.x, -right_distance, stop_frame, bounce_x)
+			velocity.x = -a[0]
+			bounce_x = a[1]
+			if a[2]: pos.x = self.size.x - content_node.size.x
 		
 		if left_distance > 0:
-			if velocity.x <= 0:
-				# Calculate dist
-				for i in stop_frame+1:
-					stop_distance += abs(vel_x)
-					vel_x *= friction
-					dist_x = stop_distance - abs(left_distance)
-					if dist_x > 0.0: break
-				# Just snap to the boundary if close enough
-				if abs(left_distance) < 0.4:
-					velocity.x = 0.0
-					pos.x = 0.0
-			# How it bounce
-			if velocity.x >= 0 or dist_x < 0.0 :
-				velocity.x = lerp(velocity.x, -left_distance/8, damping)
-				bounce_x = true
-			elif bounce_x: velocity.x = (friction-1) * left_distance
+			var a = over_bounce(velocity.x, left_distance, stop_frame, bounce_x)
+			velocity.x = a[0]
+			bounce_x = a[1]
+			if a[2]: pos.x = 0.0
 	
 	# If using scroll bar dragging, set the content_node's
 	# position by using the scrollbar position
@@ -165,45 +138,18 @@ func scroll_y():
 	
 	# Applies counterforces when overdragging
 	if not content_dragging:
-		var stop_distance = 0.0 # Distance it takes to stop
-		var dist_y = 0.0 # To see whether it is over bounce
-		var vel_y = velocity.y # Store velocity.y
-	
+		
 		if bottom_distance < 0:
-			if velocity.y >= 0:
-				# Calculate dist
-				for i in stop_frame+1:
-					stop_distance += abs(vel_y)
-					vel_y *= friction
-					dist_y = stop_distance - abs(bottom_distance)
-					if dist_y > 0.0: break
-				# Just snap to the boundary if close enough
-				if abs(bottom_distance) < 0.4:
-					velocity.y = 0.0
-					pos.y = self.size.y - content_node.size.y
-			# How it bounce
-			if velocity.y <= 0 or dist_y < 0.0 :
-				velocity.y = lerp(velocity.y, -bottom_distance/8, damping)
-				bounce_y = true
-			elif bounce_y: velocity.y = (friction-1) * bottom_distance
+			var a = over_bounce(-velocity.y, -bottom_distance, stop_frame, bounce_y)
+			velocity.y = -a[0]
+			bounce_y = a[1]
+			if a[2]: pos.y = self.size.y - content_node.size.y
 		
 		if top_distance > 0:
-			if velocity.y <= 0:
-				# Calculate dist
-				for i in stop_frame+1:
-					stop_distance += abs(vel_y)
-					vel_y *= friction
-					dist_y = stop_distance - abs(top_distance)
-					if dist_y > 0.0: break
-				# Just snap to the boundary if close enough
-				if abs(top_distance) < 0.4:
-					velocity.y = 0.0
-					pos.y = 0.0
-			# How it bounce
-			if velocity.y >= 0 or dist_y < 0.0 :
-				velocity.y = lerp(velocity.y, -top_distance/8, damping)
-				bounce_y = true
-			elif bounce_y: velocity.y = (friction-1) * top_distance
+			var a = over_bounce(velocity.y, top_distance, stop_frame, bounce_y)
+			velocity.y = a[0]
+			bounce_y = a[1]
+			if a[2]: pos.y = 0.0
 	
 	# If using scroll bar dragging, set the content_node's
 	# position by using the scrollbar position
@@ -218,6 +164,31 @@ func scroll_y():
 	
 	# Simulate friction
 	velocity.y *= friction
+
+func over_bounce(vel:float, distance:float, stop_frame:float, bounce:bool)->Array:
+	var stop_distance = 0.0 # Distance it takes to stop
+	var over_bounce = 0.0 # To see whether it is over bounce
+	var vel_temp = vel # Store velocity temporarily
+	var snap = false
+	
+	if vel <= 0:
+		# Calculate dist
+		for i in stop_frame+1:
+			stop_distance -= vel_temp
+			vel_temp *= friction
+			over_bounce = stop_distance - distance
+			if over_bounce > 0.0: break
+		# Just snap to the boundary if close enough
+		if distance < 0.4:
+			vel = 0.0
+			snap = true
+	# How it bounce
+	if vel >= 0 or over_bounce < 0.0 :
+		vel = lerp(vel, -distance/8, damping)
+		bounce = true
+	elif bounce: vel = (friction-1) * distance
+	
+	return [vel, bounce, snap]
 
 func _scrollbar_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton:

--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -51,6 +51,14 @@ var bounce_x = true
 var bounce_y = true
 # Damping to use
 var damping = 0.1
+# Distance between content_node's bottom and bottom of the scroll box 
+var bottom_distance := 0.0
+# Distance between content_node and top of the scroll box
+var top_distance := 0.0
+# Distance between content_node's right and right of the scroll box 
+var right_distance := 0.0
+# Distance between content_node and left of the scroll box
+var left_distance := 0.0
 
 
 func _ready() -> void:
@@ -64,6 +72,7 @@ func _ready() -> void:
 			content_node = c
 
 func _process(delta: float) -> void:
+	calculate_distance()
 	scroll_x()
 	scroll_y()
 	# Update vertical scroll bar
@@ -73,15 +82,21 @@ func _process(delta: float) -> void:
 	get_h_scroll_bar().set_value_no_signal(-pos.x)
 	get_h_scroll_bar().queue_redraw()
 
+func calculate_distance():
+	bottom_distance = content_node.position.y + content_node.size.y - self.size.y
+	top_distance = content_node.position.y
+	right_distance = content_node.position.x + content_node.size.x - self.size.x
+	left_distance = content_node.position.x
+	if get_v_scroll_bar().visible:
+		right_distance += get_v_scroll_bar().size.x
+	if get_h_scroll_bar().visible:
+		bottom_distance += get_h_scroll_bar().size.y
+
 func scroll_x():
 	# If no scroll needed, don't apply forces
 	if not should_scroll_horizontal():
 		return
 	
-	# Distance between content_node's right and right of the scroll box 
-	var right_distance : float = content_node.position.x + content_node.size.x - self.size.x
-	# Distance between content_node and left of the scroll box
-	var left_distance : float = content_node.position.x
 	# How long it will take to stop scrolling
 	var stop_frame = log(just_stop_under/abs(velocity.x+0.001))/log(friction*0.999)
 	stop_frame = floor(max(stop_frame, 0.0))
@@ -97,13 +112,13 @@ func scroll_x():
 			var a = over_bounce(-velocity.x, -right_distance, stop_frame, bounce_x)
 			velocity.x = -a[0]
 			bounce_x = a[1]
-			if a[2]: pos.x = self.size.x - content_node.size.x
+			if a[2]: pos.x -= right_distance
 		
 		if left_distance > 0:
 			var a = over_bounce(velocity.x, left_distance, stop_frame, bounce_x)
 			velocity.x = a[0]
 			bounce_x = a[1]
-			if a[2]: pos.x = 0.0
+			if a[2]: pos.x -= left_distance
 	
 	# If using scroll bar dragging, set the content_node's
 	# position by using the scrollbar position
@@ -124,10 +139,6 @@ func scroll_y():
 	if not should_scroll_vertical():
 		return
 	
-	# Distance between content_node's bottom and bottom of the scroll box 
-	var bottom_distance : float = content_node.position.y + content_node.size.y - self.size.y
-	# Distance between content_node and top of the scroll box
-	var top_distance : float = content_node.position.y
 	# How long it will take to stop scrolling
 	var stop_frame = log(just_stop_under/abs(velocity.y+0.001))/log(friction*0.999)
 	stop_frame = floor(max(stop_frame, 0.0))
@@ -143,13 +154,13 @@ func scroll_y():
 			var a = over_bounce(-velocity.y, -bottom_distance, stop_frame, bounce_y)
 			velocity.y = -a[0]
 			bounce_y = a[1]
-			if a[2]: pos.y = self.size.y - content_node.size.y
+			if a[2]: pos.y -= bottom_distance
 		
 		if top_distance > 0:
 			var a = over_bounce(velocity.y, top_distance, stop_frame, bounce_y)
 			velocity.y = a[0]
 			bounce_y = a[1]
-			if a[2]: pos.y = 0.0
+			if a[2]: pos.y -= top_distance
 	
 	# If using scroll bar dragging, set the content_node's
 	# position by using the scrollbar position
@@ -228,10 +239,6 @@ func _gui_input(event: InputEvent) -> void:
 	
 	if event is InputEventScreenDrag:
 		if content_dragging:
-			var bottom_distance : float = content_node.position.y + content_node.size.y - self.size.y
-			var top_distance : float = content_node.position.y
-			var right_distance : float = content_node.position.x + content_node.size.x - self.size.x
-			var left_distance : float = content_node.position.x
 			
 			if top_distance > 0.0: 
 				velocity.y = event.relative.y/(1+top_distance*damping_drag)

--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -59,6 +59,8 @@ var top_distance := 0.0
 var right_distance := 0.0
 # Distance between content_node and left of the scroll box
 var left_distance := 0.0
+# Content node position where dragging starts
+var drag_start_pos := Vector2.ZERO
 
 
 func _ready() -> void:
@@ -239,23 +241,26 @@ func _gui_input(event: InputEvent) -> void:
 	
 	if event is InputEventScreenDrag:
 		if content_dragging:
+			var y_delta = content_node.position.y - drag_start_pos.y
+			var x_delta = content_node.position.x - drag_start_pos.x
 			
-			if top_distance > 0.0: 
-				velocity.y = event.relative.y/(1+top_distance*damping_drag)
-			elif bottom_distance < 0.0:
-				velocity.y = event.relative.y/(1-bottom_distance*damping_drag)
+			if top_distance > 0.0 and min(top_distance, y_delta) > 0.0: 
+				velocity.y = event.relative.y/(1+min(top_distance, y_delta)*damping_drag)
+			elif bottom_distance < 0.0 and max(bottom_distance, y_delta) < 0.0:
+				velocity.y = event.relative.y/(1-max(bottom_distance, y_delta)*damping_drag)
 			else: velocity.y = event.relative.y
 			
-			if left_distance > 0.0: 
-				velocity.x = event.relative.x/(1+left_distance*damping_drag)
-			elif right_distance < 0.0:
-				velocity.x = event.relative.x/(1-right_distance*damping_drag)
+			if left_distance > 0.0 and min(left_distance, x_delta) > 0.0: 
+				velocity.x = event.relative.x/(1+min(left_distance, x_delta)*damping_drag)
+			elif right_distance < 0.0 and max(right_distance, x_delta) < 0.0:
+				velocity.x = event.relative.x/(1-max(right_distance, x_delta)*damping_drag)
 			else: velocity.x = event.relative.x
 	
 	if event is InputEventScreenTouch:
 		if event.pressed:
 			content_dragging = true
 			friction = 0.0
+			drag_start_pos = content_node.position
 		else:
 			content_dragging = false
 			friction = friction_drag

--- a/example.tscn
+++ b/example.tscn
@@ -28,11 +28,8 @@ offset_bottom = 393.0
 script = ExtResource("1_su8ig")
 
 [node name="Control" type="Control" parent="SmoothScrollContainer"]
-custom_minimum_size = Vector2i(0, 943)
+custom_minimum_size = Vector2(0, 943)
 layout_mode = 2
-anchors_preset = 0
-offset_right = 382.0
-offset_bottom = 943.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
@@ -63,7 +60,7 @@ suscipit quas? Nulla, placeat. Voluptatem quaerat non architecto ab laudantium
 modi minima sunt esse temporibus sint culpa, recusandae aliquam numquam 
 totam ratione voluptas quod exercitationem fuga. Possimus quis earum veniam 
 quasi aliquam eligendi, placeat qui corporis!"
-fit_content_height = true
+fit_content = true
 
 [node name="Button" type="Button" parent="SmoothScrollContainer/Control"]
 layout_mode = 0


### PR DESCRIPTION
Full support of horizontal scrolling, as well as relative function.
scroll_to_... functions are all using tween now.
I changed set_h/v_scroll() to get_h/v_scroll_bar().set_value_with_no_signal() and queue_redraw, as the former function tries to pull content back to boundary, which caused flicker like #2.