### PR TITLE
Fix issue with is_scrolling and hiding scroll bar

### DIFF
--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -83,6 +83,8 @@ var left_distance := 0.0
 var drag_start_pos := Vector2.ZERO
 # Timer for hiding scroll bar
 var scrollbar_hide_timer := Timer.new()
+# Tween for hiding scroll bar
+var scrollbar_hide_tween : Tween
 # [0,1] Mouse or touch's relative movement accumulation when overdrag
 # [2,3,4,5] Top_distance, bottom_distance, left_distance, right_distance
 var drag_temp_data := []
@@ -119,6 +121,7 @@ func _ready() -> void:
 	
 	add_child(scrollbar_hide_timer)
 	scrollbar_hide_timer.timeout.connect(_scrollbar_hide_timer_timeout)
+	scrollbar_hide_timer.start(scrollbar_hide_time)
 	get_tree().node_added.connect(_on_node_added)
 
 func _process(delta: float) -> void:
@@ -604,16 +607,20 @@ func should_scroll_horizontal() -> bool:
 		return true
 
 func hide_scrollbars() -> void:
-	var t := create_tween()
-	t.tween_property(get_v_scroll_bar(), 'modulate', Color.TRANSPARENT, scrollbar_fade_out_time)
-	t.tween_property(get_h_scroll_bar(), 'modulate', Color.TRANSPARENT, scrollbar_fade_out_time)
-	t.play()
+	if scrollbar_hide_tween != null:
+		scrollbar_hide_tween.kill()
+	scrollbar_hide_tween = create_tween()
+	scrollbar_hide_tween.set_parallel(true)
+	scrollbar_hide_tween.tween_property(get_v_scroll_bar(), 'modulate', Color.TRANSPARENT, scrollbar_fade_out_time)
+	scrollbar_hide_tween.tween_property(get_h_scroll_bar(), 'modulate', Color.TRANSPARENT, scrollbar_fade_out_time)
 
 func show_scrollbars() -> void:
-	var t := create_tween()
-	t.tween_property(get_v_scroll_bar(), 'modulate', Color.WHITE, scrollbar_fade_in_time)
-	t.tween_property(get_h_scroll_bar(), 'modulate', Color.WHITE, scrollbar_fade_in_time)
-	t.play()
+	if scrollbar_hide_tween != null:
+		scrollbar_hide_tween.kill()
+	scrollbar_hide_tween = create_tween()
+	scrollbar_hide_tween.set_parallel(true)
+	scrollbar_hide_tween.tween_property(get_v_scroll_bar(), 'modulate', Color.WHITE, scrollbar_fade_in_time)
+	scrollbar_hide_tween.tween_property(get_h_scroll_bar(), 'modulate', Color.WHITE, scrollbar_fade_in_time)
 
 ##### API FUNCTIONS
 ########################

--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -37,10 +37,11 @@ var friction_scroll := 0.9
 var friction_drag := 0.9
 ## Hides scrollbar as long as not hovered or interacted with
 @export
-var hide_scrollbar_over_time:= false
+var hide_scrollbar_over_time:= false:
+	set(val): hide_scrollbar_over_time = _set_hide_scrollbar_over_time(val)
 ## Time after scrollbar starts to fade out when 'hide_scrollbar_over_time' is true
 @export
-var scrollbar_hide_time := 5
+var scrollbar_hide_time := 5.0
 ## Fadein time for scrollbar when 'hide_scrollbar_over_time' is true
 @export
 var scrollbar_fade_in_time := 0.2
@@ -121,7 +122,8 @@ func _ready() -> void:
 	
 	add_child(scrollbar_hide_timer)
 	scrollbar_hide_timer.timeout.connect(_scrollbar_hide_timer_timeout)
-	scrollbar_hide_timer.start(scrollbar_hide_time)
+	if hide_scrollbar_over_time:
+		scrollbar_hide_timer.start(scrollbar_hide_time)
 	get_tree().node_added.connect(_on_node_added)
 
 func _process(delta: float) -> void:
@@ -295,6 +297,18 @@ func _scrollbar_hide_timer_timeout() -> void:
 	if !any_scroll_bar_dragged():
 		hide_scrollbars()
 
+func _set_hide_scrollbar_over_time(value) -> bool:
+	if value == false:
+		if scrollbar_hide_timer != null:
+			scrollbar_hide_timer.stop()
+		if scrollbar_hide_tween != null:
+			scrollbar_hide_tween.kill()
+		get_h_scroll_bar().modulate = Color.WHITE
+		get_v_scroll_bar().modulate = Color.WHITE
+	else:
+		if scrollbar_hide_timer != null and scrollbar_hide_timer.is_inside_tree():
+			scrollbar_hide_timer.start(scrollbar_hide_time)
+	return value
 ##### Virtual functions
 ####################
 

--- a/example.tscn
+++ b/example.tscn
@@ -21,6 +21,14 @@ script/source = "extends RichTextLabel
 
 # Called when the node enters the scene tree for the first time.
 func _process(delta):
+	update_text()
+
+func _ready():
+	update_text()
+	scroll_to_line(get_line_count())
+
+
+func update_text():
 	text = \"\"
 	
 	var thisScript: GDScript = %SmoothScrollContainer.get_script()
@@ -124,7 +132,6 @@ size_flags_vertical = 3
 mouse_filter = 1
 bbcode_enabled = true
 text = "[Property values]"
-scroll_following = true
 script = SubResource("GDScript_xu50n")
 
 [node name="HSlider" type="HSlider" parent="."]

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Smooth Scroll"
 run/main_scene="res://example.tscn"
-config/features=PackedStringArray("4.0")
+config/features=PackedStringArray("4.1")
 config/icon="res://addons/SmoothScroll/class-icon.svg"
 
 [display]


### PR DESCRIPTION
I found **is_scrolling** presenting wrong value due to velocity not being 0.
![Scrolling Issue](https://github.com/SpyrexDE/SmoothScroll/assets/80692930/a9f057cc-8088-4597-b7da-7324e982edec)
Therefore, I refactor **should_scroll**. Now all "allow_scoll_horizontal/vertical" are replaced with should_scroll_horizontal/vertical().
Also, I found there was snapping issue and I fixed it.

There was flickering issue with scroll bar, because showing and hiding tweeners are fighting. You can try scrollbar_fade_in_time=0.2, scrollbar_fade_out_time=2.0 and you will see the issue.
![Tween Issue](https://github.com/SpyrexDE/SmoothScroll/assets/80692930/78ab1d15-cc4e-41c2-b215-85eb53f8e83b)
I kill() the existing tween and create a new one.
And I add a timer.start() in _ready() because there might be no input for a while once container enter scene tree.

Now the scoll bar alpha will be refresh if hide_scrollbar_over_time is changed.
![Refresh Scoll Bar Alpha](https://github.com/SpyrexDE/SmoothScroll/assets/80692930/a439e6d5-72e5-47dd-9a8e-e0c6cdb94e6c)
