### PR TITLE
Add toggle for overshoot

### DIFF
--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -392,7 +392,7 @@ func handle_overdrag(vertical : bool, axis_velocity : float, axis_pos : float) -
 	
 	var result = [axis_velocity, axis_pos]
 	
-	if not (dist1 > 0 or dist2 < 0) and will_stop_within(vertical, axis_velocity):
+	if not (dist1 > 0 or dist2 < 0) or will_stop_within(vertical, axis_velocity):
 		return result
 
 	# Overdrag on top or left


### PR DESCRIPTION
Can disable overshoot. The scrollbar will smoothly snap to the boundary.

I also made some changes to "handle_overdrag" method logic flow. I have tested and not noticed any bugs.

[2023-10-22 - Toggle Overshoot.webm](https://github.com/SpyrexDE/SmoothScroll/assets/26135914/6e58f990-7886-4bfe-981a-e4be9bc8e29e)

![image](https://github.com/SpyrexDE/SmoothScroll/assets/26135914/420fb784-4e6a-4bac-83f7-f6ad12ccd5f3)

