### PR TITLE
Fix scroll to tweens not being killed properly

### DIFF
--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -321,6 +321,7 @@ func _set(property, value) -> bool:
 				scroll_horizontal = 0
 				return true
 			scroll_horizontal = value
+			kill_scroll_x_to_tween()
 			velocity.x = 0.0
 			pos.x = clampf(
 				-value as float,
@@ -333,6 +334,7 @@ func _set(property, value) -> bool:
 				scroll_vertical = 0
 				return true
 			scroll_vertical = value
+			kill_scroll_y_to_tween()
 			velocity.y = 0.0
 			pos.y = clampf(
 				-value as float,


### PR DESCRIPTION
Minor bug fix.
```GDScript
func _set(property, value) -> bool:
	match property:
		"scroll_horizontal":
			if !content_node:
				scroll_horizontal = 0
				return true
			scroll_horizontal = value
			kill_scroll_x_to_tween()	# new
			velocity.x = 0.0
			pos.x = clampf(
				-value as float,
				-get_child_size_x_diff(content_node, true),
				0.0
			)
			return true
		"scroll_vertical":
			if !content_node:
				scroll_vertical = 0
				return true
			scroll_vertical = value
			kill_scroll_y_to_tween()	# new
			velocity.y = 0.0
			pos.y = clampf(
				-value as float,
				-get_child_size_y_diff(content_node, true),
				0.0
			)
			return true
		_:
			return false
```
Just a digression. #58 