### PR TITLE
Fix scroll bar dragging state

### DIFF
--- a/addons/SmoothScroll/SmoothScrollContainer.gd
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd
@@ -165,9 +165,11 @@ func _scrollbar_input(event: InputEvent, vertical : bool) -> void:
 			if event.pressed:
 				if vertical:
 					v_scrollbar_dragging = true
+					last_scroll_type = SCROLL_TYPE.BAR
 					kill_scroll_to_tweens()
 				else:
 					h_scrollbar_dragging = true
+					last_scroll_type = SCROLL_TYPE.BAR
 					kill_scroll_to_tweens()
 			else:
 				if vertical:
@@ -179,9 +181,11 @@ func _scrollbar_input(event: InputEvent, vertical : bool) -> void:
 		if event.pressed:
 			if vertical:
 				v_scrollbar_dragging = true
+				last_scroll_type = SCROLL_TYPE.BAR
 				kill_scroll_to_tweens()
 			else:
 				h_scrollbar_dragging = true
+				last_scroll_type = SCROLL_TYPE.BAR
 				kill_scroll_to_tweens()
 		else:
 			if vertical:


### PR DESCRIPTION
Close #61 
- Remove `_on_HScrollBar_scrolling()` and `_on_VScrollBar_scrolling()`.
- Now scroll bar dragging logic is the same as content dragging.
- `any_scroll_bar_dragged()` simply return `h_scrollbar_dragging or v_scrollbar_dragging`
- Fix a mistake in `update_state`