### PR TITLE
Fix scrolling stuck when releasing dragging with touch

### DIFF
--- a/addons/SmoothScroll/SmoothScrollContainer.gd.uid
+++ b/addons/SmoothScroll/SmoothScrollContainer.gd.uid
@@ -1,0 +1,1 @@
+uid://bgqglerkcylxx

--- a/addons/SmoothScroll/plugin.gd.uid
+++ b/addons/SmoothScroll/plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://b7svd7w4nwpch

--- a/addons/SmoothScroll/scroll_damper/cubic_scroll_damper.gd.uid
+++ b/addons/SmoothScroll/scroll_damper/cubic_scroll_damper.gd.uid
@@ -1,0 +1,1 @@
+uid://dlagxcnf11lr4

--- a/addons/SmoothScroll/scroll_damper/expo_scroll_damper.gd.uid
+++ b/addons/SmoothScroll/scroll_damper/expo_scroll_damper.gd.uid
@@ -1,0 +1,1 @@
+uid://b7h0k2h2qwlqv

--- a/addons/SmoothScroll/scroll_damper/linear_scroll_damper.gd.uid
+++ b/addons/SmoothScroll/scroll_damper/linear_scroll_damper.gd.uid
@@ -1,0 +1,1 @@
+uid://dvvc75dvopgcg

--- a/addons/SmoothScroll/scroll_damper/quad_scroll_damper.gd.uid
+++ b/addons/SmoothScroll/scroll_damper/quad_scroll_damper.gd.uid
@@ -1,0 +1,1 @@
+uid://ccgjrqkk3oksk

--- a/addons/SmoothScroll/scroll_damper/scroll_damper.gd.uid
+++ b/addons/SmoothScroll/scroll_damper/scroll_damper.gd.uid
@@ -1,0 +1,1 @@
+uid://bcy471w0pi8af

--- a/example.tscn
+++ b/example.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=7 format=3 uid="uid://xqy4fhlaf2q3"]
 
-[ext_resource type="Script" path="res://addons/SmoothScroll/SmoothScrollContainer.gd" id="1_su8ig"]
-[ext_resource type="Script" path="res://addons/SmoothScroll/scroll_damper/expo_scroll_damper.gd" id="2_ibjlc"]
+[ext_resource type="Script" uid="uid://bgqglerkcylxx" path="res://addons/SmoothScroll/SmoothScrollContainer.gd" id="1_su8ig"]
+[ext_resource type="Script" uid="uid://b7h0k2h2qwlqv" path="res://addons/SmoothScroll/scroll_damper/expo_scroll_damper.gd" id="2_ibjlc"]
 
 [sub_resource type="GDScript" id="GDScript_xo176"]
 script/source = "extends Control

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="Smooth Scroll"
 run/main_scene="res://example.tscn"
-config/features=PackedStringArray("4.3")
+config/features=PackedStringArray("4.4")
 config/icon="res://addons/SmoothScroll/class-icon.svg"
 
 [display]


### PR DESCRIPTION
Better way for ac4eb63 #67 
ac4eb63 fixed that issue yet cause another problem. When dragging moves and stops for a while, content will still scroll when releasing dragging.

https://github.com/user-attachments/assets/78c7851e-8703-4e52-8a3d-ca0ba3971b3b

I guess the main issue is that at the frame of releasing dragging, there might be no movement event on mobile devices, which leaves velocity to zero. So, I managed to preserve velocity for 1 frame to avoid the case.

- Before ac4eb63 (mobile)
You can see sudden stuck when releasing dragging.

https://github.com/user-attachments/assets/5840ced7-792d-482f-8f37-87a7996e5aba

This PR (mobile)

https://github.com/user-attachments/assets/9ed92e2e-e5ec-48d5-bd1a-17671e642c54

Need more test.