### PR TITLE
Add dirty update mechanism and fix content margin retrieval and boundary deviation.

### DIFF
--- a/addons/SmoothScroll/helpers/scroll_layout.gd
+++ b/addons/SmoothScroll/helpers/scroll_layout.gd
@@ -27,7 +27,7 @@ static func get_spare_size_y(container: Control, content_margins: Vector4) -> fl
 	
 	if h_scroll_bar.visible:
 		size_y -= h_scroll_bar.size.y
-	
+
 	size_y -= content_margins.y + content_margins.w
 	return max(size_y, 0.0)
 
@@ -138,10 +138,10 @@ static func get_content_margins(container: Control) -> Vector4:
 	var style_box: StyleBox = container.get_theme_stylebox("panel")
 	if style_box:
 		return Vector4(
-			style_box.content_margin_left,
-			style_box.content_margin_top,
-			style_box.content_margin_right,
-			style_box.content_margin_bottom
+			max(style_box.content_margin_left, 0),
+			max(style_box.content_margin_top, 0),
+			max(style_box.content_margin_right, 0),
+			max(style_box.content_margin_bottom, 0)
 		)
 	else:
 		return Vector4.ZERO

--- a/addons/SmoothScroll/helpers/scroll_physics.gd
+++ b/addons/SmoothScroll/helpers/scroll_physics.gd
@@ -53,16 +53,14 @@ static func apply_snap(
 	
 	# Snap to start boundary
 	if (
-		dist_to_start > 0.0
-		and abs(dist_to_start) < snap_threshold
+		abs(dist_to_start) < snap_threshold
 		and abs(axis_velocity) < snap_threshold
 	):
 		axis_pos = 0.0
 		axis_velocity = 0.0
 	# Snap to end boundary
 	elif (
-		dist_to_end < 0.0
-		and abs(dist_to_end) < snap_threshold
+		abs(dist_to_end) < snap_threshold
 		and abs(axis_velocity) < snap_threshold
 	):
 		axis_pos = -size_diff

--- a/addons/SmoothScroll/smooth_scroll_container.gd
+++ b/addons/SmoothScroll/smooth_scroll_container.gd
@@ -5,7 +5,6 @@ extends ScrollContainer
 ##
 ## Applies velocity based momentum and "overdrag"
 ## functionality to a ScrollContainer.
-## Includes dirty update optimization to save performance when idle.
 
 
 #region Variables
@@ -106,7 +105,7 @@ var _initial_margins_skipped: bool = false
 var scrollbar_animator: ScrollbarAnimator
 ## Input handler for all user input events
 var input_handler: ScrollInputHandler
-## Detect whether the script is running on an editor
+## Cache is_editor_hint() value for performance
 var _is_editor_hint = Engine.is_editor_hint()
 #endregion
 
@@ -163,6 +162,7 @@ func _ready() -> void:
 	
 	if _is_editor_hint:
 		get_tree().node_added.connect(_on_node_added)
+	
 	# Default to idle state until needed
 	set_process(false)
 
@@ -179,7 +179,6 @@ func _process(delta: float) -> void:
 
 	if debug_mode: queue_redraw()
 	
-	# Optimization: Check if we can sleep
 	if not is_scrolling:
 		set_process(false)
 #endregion
@@ -194,13 +193,13 @@ func _mouse_on_scroll_bar(entered: bool) -> void:
 ## Forwards scroll inputs from the specified scrollbar to the input handler. [br]
 ## Handles both [param vertical] and horizontal scrollbar [param event] inputs.
 func _scrollbar_input(event: InputEvent, vertical: bool) -> void:
-	set_process(true) # Wake up on interaction
+	set_process(true)
 	input_handler.process_scrollbar_input(event, vertical)
 
 
 ## Handles all GUI input events by delegating them to the input handler.
 func _gui_input(event: InputEvent) -> void:
-	set_process(true) # Wake up on interaction
+	set_process(true)
 	input_handler.process_gui_input(event)
 
 
@@ -232,7 +231,7 @@ func _scrollbar_hide_timer_timeout() -> void:
 ## Updates content margins from the current StyleBox. [br]
 ## Captures baseline offset and clears velocity to keep scroll math in margin-free space.
 func _update_content_margins() -> void:
-	set_process(true) # Wake up to apply new layout
+	set_process(true)
 	_initializing_margins = true
 	
 	content_margins = ScrollLayout.get_content_margins(self)
@@ -316,7 +315,7 @@ func _set(property: StringName, value: Variant) -> bool:
 				-ScrollLayout.get_child_size_x_diff(content_node, spare_size_x, true),
 				0.0
 			)
-			# Important: Wake up process to ensure scrollbars update visually
+			# Wake up process to ensure scrollbars update visually
 			set_process(true) 
 			return true
 		
@@ -534,7 +533,7 @@ func scroll_x_to(x_pos: float, duration := 0.5) -> void:
 	if not should_scroll_horizontal(): return
 	if input_handler.content_dragging: return
 	
-	set_process(true) # Ensure tweens update visual state in _process if needed, or subsequent sets do
+	set_process(true)
 	velocity.x = 0.0
 	var spare_size_x: float = ScrollLayout.get_spare_size_x(self, content_margins)
 	var size_x_diff: float = ScrollLayout.get_child_size_x_diff(content_node, spare_size_x, true)
@@ -549,7 +548,7 @@ func scroll_y_to(y_pos: float, duration := 0.5) -> void:
 	if not should_scroll_vertical(): return
 	if input_handler.content_dragging: return
 
-	set_process(true) # Ensure tweens update visual state in _process if needed
+	set_process(true)
 	velocity.y = 0.0
 	var spare_size_y: float = ScrollLayout.get_spare_size_y(self, content_margins)
 	var size_y_diff: float = ScrollLayout.get_child_size_y_diff(content_node, spare_size_y, true)
@@ -586,14 +585,14 @@ func scroll_page_right(duration := 0.5) -> void:
 ## Positive [param amount] scrolls up, negative scrolls down.
 func scroll_vertically(amount: float) -> void:
 	velocity.y -= amount
-	set_process(true) # Wake up physics
+	set_process(true)
 
 
 ## Adds velocity to the horizontal scroll for momentum-based scrolling. [br]
 ## Positive [param amount] scrolls left, negative scrolls right.
 func scroll_horizontally(amount: float) -> void:
 	velocity.x -= amount
-	set_process(true) # Wake up physics
+	set_process(true)
 
 
 ## Scrolls to the top with a tween animation. Duration is specified by [param duration] in seconds.

--- a/addons/SmoothScroll/smooth_scroll_container.gd
+++ b/addons/SmoothScroll/smooth_scroll_container.gd
@@ -5,6 +5,7 @@ extends ScrollContainer
 ##
 ## Applies velocity based momentum and "overdrag"
 ## functionality to a ScrollContainer.
+## Includes dirty update optimization to save performance when idle.
 
 
 #region Variables
@@ -105,6 +106,8 @@ var _initial_margins_skipped: bool = false
 var scrollbar_animator: ScrollbarAnimator
 ## Input handler for all user input events
 var input_handler: ScrollInputHandler
+## Detect whether the script is running on an editor
+var _is_editor_hint = Engine.is_editor_hint()
 #endregion
 
 #endregion
@@ -144,7 +147,6 @@ func _ready() -> void:
 	# Check if we're initially hidden - if so, defer margin calculation until visible
 	if visible:
 		call_deferred("_update_content_margins")
-	
 	else:
 		_initial_margins_skipped = true
 
@@ -159,12 +161,15 @@ func _ready() -> void:
 	if hide_scrollbar_over_time:
 		scrollbar_animator.start_hide_timer()
 	
-	get_tree().node_added.connect(_on_node_added)
+	if _is_editor_hint:
+		get_tree().node_added.connect(_on_node_added)
+	# Default to idle state until needed
+	set_process(false)
 
 
 ## Called every frame. Updates scroll position, velocity, and scrollbar state.
 func _process(delta: float) -> void:
-	if Engine.is_editor_hint(): return
+	if _is_editor_hint: return
 	if _initializing_margins: return
 
 	scroll(true, velocity.y, pos.y, delta)
@@ -173,6 +178,10 @@ func _process(delta: float) -> void:
 	update_is_scrolling()
 
 	if debug_mode: queue_redraw()
+	
+	# Optimization: Check if we can sleep
+	if not is_scrolling:
+		set_process(false)
 #endregion
 
 
@@ -185,11 +194,13 @@ func _mouse_on_scroll_bar(entered: bool) -> void:
 ## Forwards scroll inputs from the specified scrollbar to the input handler. [br]
 ## Handles both [param vertical] and horizontal scrollbar [param event] inputs.
 func _scrollbar_input(event: InputEvent, vertical: bool) -> void:
+	set_process(true) # Wake up on interaction
 	input_handler.process_scrollbar_input(event, vertical)
 
 
 ## Handles all GUI input events by delegating them to the input handler.
 func _gui_input(event: InputEvent) -> void:
+	set_process(true) # Wake up on interaction
 	input_handler.process_gui_input(event)
 
 
@@ -207,7 +218,7 @@ func _draw() -> void:
 ## Sets default mouse filter for SmoothScroll children to [constant Control.MOUSE_FILTER_PASS]. [br]
 ## Called when a [param node] is added to the tree.
 func _on_node_added(node: Node) -> void:
-	if node is Control and Engine.is_editor_hint():
+	if node is Control:
 		if is_ancestor_of(node):
 			node.mouse_filter = Control.MOUSE_FILTER_PASS
 
@@ -221,6 +232,7 @@ func _scrollbar_hide_timer_timeout() -> void:
 ## Updates content margins from the current StyleBox. [br]
 ## Captures baseline offset and clears velocity to keep scroll math in margin-free space.
 func _update_content_margins() -> void:
+	set_process(true) # Wake up to apply new layout
 	_initializing_margins = true
 	
 	content_margins = ScrollLayout.get_content_margins(self)
@@ -304,6 +316,8 @@ func _set(property: StringName, value: Variant) -> bool:
 				-ScrollLayout.get_child_size_x_diff(content_node, spare_size_x, true),
 				0.0
 			)
+			# Important: Wake up process to ensure scrollbars update visually
+			set_process(true) 
 			return true
 		
 		"scroll_vertical":
@@ -322,7 +336,8 @@ func _set(property: StringName, value: Variant) -> bool:
 				-ScrollLayout.get_child_size_y_diff(content_node, spare_size_y, true),
 				0.0
 			)
-
+			# Important: Wake up process to ensure scrollbars update visually
+			set_process(true)
 			return true
 		_:
 			return false
@@ -518,7 +533,8 @@ func update_scrollbars() -> void:
 func scroll_x_to(x_pos: float, duration := 0.5) -> void:
 	if not should_scroll_horizontal(): return
 	if input_handler.content_dragging: return
-
+	
+	set_process(true) # Ensure tweens update visual state in _process if needed, or subsequent sets do
 	velocity.x = 0.0
 	var spare_size_x: float = ScrollLayout.get_spare_size_x(self, content_margins)
 	var size_x_diff: float = ScrollLayout.get_child_size_x_diff(content_node, spare_size_x, true)
@@ -533,6 +549,7 @@ func scroll_y_to(y_pos: float, duration := 0.5) -> void:
 	if not should_scroll_vertical(): return
 	if input_handler.content_dragging: return
 
+	set_process(true) # Ensure tweens update visual state in _process if needed
 	velocity.y = 0.0
 	var spare_size_y: float = ScrollLayout.get_spare_size_y(self, content_margins)
 	var size_y_diff: float = ScrollLayout.get_child_size_y_diff(content_node, spare_size_y, true)
@@ -569,12 +586,14 @@ func scroll_page_right(duration := 0.5) -> void:
 ## Positive [param amount] scrolls up, negative scrolls down.
 func scroll_vertically(amount: float) -> void:
 	velocity.y -= amount
+	set_process(true) # Wake up physics
 
 
 ## Adds velocity to the horizontal scroll for momentum-based scrolling. [br]
 ## Positive [param amount] scrolls left, negative scrolls right.
 func scroll_horizontally(amount: float) -> void:
 	velocity.x -= amount
+	set_process(true) # Wake up physics
 
 
 ## Scrolls to the top with a tween animation. Duration is specified by [param duration] in seconds.
@@ -638,6 +657,9 @@ func ensure_control_visible_smooth(control: Control) -> void:
 	if not content_node.is_ancestor_of(control): return
 	if not scroll_damper: return
 	
+	# Wake up to process the potential scroll action
+	set_process(true)
+
 	var size_diff: Vector2 = (
 		control.get_global_rect().size - get_global_rect().size
 	) / (get_global_rect().size / size)


### PR DESCRIPTION
Added a dirty update mechanism to avoid unnecessary CPU usage.  
On my laptop (i5 9300h), the CPU usage during idle dropped from 0.9% to 0.3-0.4%, which isn't much for games but is essential for non-gaming applications.

Also identified and fixed an issue with retrieving the content margin.
The default value of `style_box.content_margin_*` is -1, and using it directly cause the content to scroll back a few pixels at the end, resulting in incomplete display.

Addendum: Removed unnecessary `dist_to_*` checks in `ScrollPhysics.apply_snap`. The original code could cause a slight discrepancy between the final resting position and the boundary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reduce idle CPU by processing only when needed, clamp negative StyleBox margins, and streamline snap-to-boundary logic.
> 
> - **Performance/Processing**:
>   - Add idle gating: default `set_process(false)`, wake on input/scroll APIs, and auto-stop when not scrolling to reduce idle CPU in `SmoothScrollContainer`.
>   - Cache `Engine.is_editor_hint()` and limit `node_added` hookup to editor; guard `_process` in editor.
> - **Layout/Margins**:
>   - Clamp `StyleBox.content_margin_*` to non-negative in `ScrollLayout.get_content_margins` to avoid invalid (-1) margins affecting scroll bounds.
> - **Physics/Snapping**:
>   - Simplify `ScrollPhysics.apply_snap` by removing sign checks; snap when distance and velocity are below threshold regardless of direction.
> - **UX**:
>   - Ensure processing wakes during property sets and inputs so scrollbar visuals update immediately.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bba1524987f3e7a861fd40393a43efddc4784b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->