### PR TITLE
Add dynamic alpha clipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,51 @@
 # <img src="./addons/SmoothScroll/class-icon.svg" alt="drawing" width="20" style="padding-top: 20px;"/>   SmoothScroll
- A customizable SmoothScrollContainer node for Godot
+A customizable `SmoothScrollContainer` node for Godot.
 
 [Watch video footage on Youtube](https://www.youtube.com/watch?v=B3GjqV2c6yQ)
 
 ### How to use
-Activate the addon in the project settings' addon tab,
-Click the "+" button to add a new node and select "SmoothScrollContainer" instead "ScrollContainer".
-To add smooth scrollling to existing ScrollContainers, rightclick the node and select change type. Then select "SmoothScrollContainer".
+Activate the addon in the project settings' **Addon** tab. Add a new
+`SmoothScrollContainer` node, or right-click an existing `ScrollContainer`,
+choose **Change Type**, and select `SmoothScrollContainer`.
+
+Put one `Control` child inside the container as the scrollable content. The
+container supports vertical and horizontal scrolling and automatically limits
+scrolling to axes where the content overflows.
 
 For smoother scrolling: In your project settings set _gui/common/snap_controls_to_pixels_ to _false_
+
+### Features
+
+- Momentum-based mouse-wheel scrolling with configurable scroll dampers.
+- Mouse and touch content dragging with configurable drag dampers.
+- Optional overdragging and boundary snapping.
+- Smooth scrollbar scrolling and optional scrollbar auto-hide/fade.
+- Smooth scrolling to positions, pages, boundaries, and focused controls.
+- Automatic child mouse-filter setup so content remains draggable.
+- Optional vertical or horizontal alpha-gradient clipping at the container
+  edges.
+
+### Alpha clipping
+
+Alpha clipping is disabled by default. Enable the `clipping_gradient` property
+on `SmoothScrollContainer` and choose `Vertical` or `Horizontal`. Adjust
+`clipping_gradient_size` to control the fade width in pixels.
+
+The clipping is dynamic: the gradient at the starting edge is disabled while
+the content is at the start, and the gradient at the ending edge is disabled
+when the content reaches the end. This prevents content from appearing faded
+while the scrollable area is at rest on either boundary.
+
+```gdscript
+@onready var scroll_container: SmoothScrollContainer = $SmoothScrollContainer
+
+func _ready() -> void:
+	scroll_container.clipping_gradient = 1 # Vertical
+	scroll_container.clipping_gradient_size = 32.0
+```
+
+The alpha mask is implemented by
+`addons/SmoothScroll/clipping_gradient.gdshader`. Existing content materials
+are restored when clipping is disabled.
 
 `Mouse scroll icon by Greg Fiske from the Noun Project`

--- a/addons/SmoothScroll/clipping_gradient.gdshader
+++ b/addons/SmoothScroll/clipping_gradient.gdshader
@@ -1,0 +1,23 @@
+shader_type canvas_item;
+
+uniform int direction : hint_range(0, 1) = 0;
+uniform float fade_size = 32.0;
+uniform vec4 mask_rect = vec4(0.0, 0.0, 1.0, 1.0);
+uniform vec2 viewport_size = vec2(1.0);
+// x: start edge, y: end edge. Disabled edges remain fully opaque.
+uniform vec2 edge_mask = vec2(0.0, 0.0);
+
+void fragment() {
+	vec2 rect_size = mask_rect.zw - mask_rect.xy;
+	vec2 mask_uv = (SCREEN_UV - mask_rect.xy) / max(rect_size, vec2(0.0001));
+	float edge_size = direction == 0
+		? fade_size / max(1.0, rect_size.y * viewport_size.y)
+		: fade_size / max(1.0, rect_size.x * viewport_size.x);
+
+	float coordinate = direction == 0 ? mask_uv.y : mask_uv.x;
+	float start_inside = smoothstep(0.0, edge_size, coordinate);
+	float end_inside = 1.0 - smoothstep(1.0 - edge_size, 1.0, coordinate);
+	float inside = mix(1.0, start_inside, edge_mask.x)
+		* mix(1.0, end_inside, edge_mask.y);
+	COLOR.a *= clamp(inside, 0.0, 1.0);
+}

--- a/addons/SmoothScroll/clipping_gradient.gdshader.uid
+++ b/addons/SmoothScroll/clipping_gradient.gdshader.uid
@@ -1,0 +1,1 @@
+uid://dbrtp2w480pn1

--- a/addons/SmoothScroll/smooth_scroll_container.gd
+++ b/addons/SmoothScroll/smooth_scroll_container.gd
@@ -48,6 +48,18 @@ enum SCROLL_TYPE {
 ## before interpolating back to its bounds
 @export var allow_overdragging: bool = true
 
+## Adds a soft clipping gradient at the start and end of the scrollable area.
+## The gradient is used as an alpha mask for the scrollable content.
+@export_enum("Disabled", "Vertical", "Horizontal") var clipping_gradient: int = 0:
+	set(value):
+		clipping_gradient = value
+		_update_clipping_gradient()
+## Width of each clipping gradient edge in pixels.
+@export_range(0.0, 500.0, 1.0, "or_greater") var clipping_gradient_size: float = 32.0:
+	set(value):
+		clipping_gradient_size = value
+		_update_clipping_gradient()
+
 @export_group("Scroll Bar")
 ## Hides scrollbar as long as not hovered or interacted with
 @export var hide_scrollbar_over_time: bool = false:
@@ -120,6 +132,10 @@ var _size_stable_frames := 0
 var _pending_ensure_control: Control = null
 ## Timer to check for size stability
 var _ensure_stability_timer: Timer = null
+## Material used to apply the alpha mask to content canvas items.
+var _clipping_gradient_material: ShaderMaterial
+## Original content materials restored when the mask is disabled.
+var _clipping_gradient_original_materials: Dictionary = {}
 #endregion
 
 #endregion
@@ -179,6 +195,8 @@ func _ready() -> void:
 			call_deferred("_apply_mouse_filters_to_children")
 	
 	# Default to idle state until needed
+	_setup_clipping_gradient()
+	resized.connect(_update_clipping_gradient)
 	set_process(false)
 
 
@@ -189,6 +207,7 @@ func _process(delta: float) -> void:
 
 	scroll(true, velocity.y, pos.y, delta)
 	scroll(false, velocity.x, pos.x, delta)
+	_update_clipping_gradient_edges()
 	update_scrollbars()
 	update_is_scrolling()
 
@@ -229,6 +248,101 @@ func _draw() -> void:
 	if debug_mode: ScrollDebugger.draw_debug(self)
 
 
+## Creates and updates the optional clipping gradient mask.
+func _setup_clipping_gradient() -> void:
+	if _clipping_gradient_material:
+		_update_clipping_gradient()
+		return
+
+	_clipping_gradient_material = ShaderMaterial.new()
+	_clipping_gradient_material.shader = preload("clipping_gradient.gdshader")
+	_update_clipping_gradient()
+
+
+func _update_clipping_gradient() -> void:
+	if not _clipping_gradient_material: return
+
+	var enabled := clipping_gradient != 0 and clipping_gradient_size > 0.0
+	if enabled:
+		_apply_clipping_gradient_materials()
+	else:
+		_restore_clipping_gradient_materials()
+
+	_clipping_gradient_material.set_shader_parameter("direction", int(clipping_gradient == 2))
+	_clipping_gradient_material.set_shader_parameter("fade_size", clipping_gradient_size)
+	_update_clipping_gradient_edges()
+	_update_clipping_gradient_rect()
+	queue_redraw()
+
+
+func _apply_clipping_gradient_materials() -> void:
+	if not content_node: return
+	for node in _get_content_canvas_items(content_node):
+		if not _clipping_gradient_original_materials.has(node):
+			_clipping_gradient_original_materials[node] = node.material
+		node.material = _clipping_gradient_material
+
+
+func _restore_clipping_gradient_materials() -> void:
+	for node: CanvasItem in _clipping_gradient_original_materials:
+		if is_instance_valid(node):
+			node.material = _clipping_gradient_original_materials[node]
+	_clipping_gradient_original_materials.clear()
+
+
+## Enables each fade edge only while content remains on that side of the viewport.
+func _update_clipping_gradient_edges() -> void:
+	if not _clipping_gradient_material: return
+
+	var edge_mask := Vector2.ZERO
+	if clipping_gradient != 0 and clipping_gradient_size > 0.0 and content_node:
+		if clipping_gradient == 1:
+			var size_diff_y := ScrollLayout.get_child_size_y_diff(
+				content_node, ScrollLayout.get_spare_size_y(self, content_margins), true
+			)
+			edge_mask = Vector2(
+				float(pos.y < -0.001),
+				float(pos.y > -size_diff_y + 0.001)
+			)
+		else:
+			var size_diff_x := ScrollLayout.get_child_size_x_diff(
+				content_node, ScrollLayout.get_spare_size_x(self, content_margins), true
+			)
+			edge_mask = Vector2(
+				float(pos.x < -0.001),
+				float(pos.x > -size_diff_x + 0.001)
+			)
+
+	_clipping_gradient_material.set_shader_parameter("edge_mask", edge_mask)
+
+
+func _get_content_canvas_items(node: Node) -> Array[CanvasItem]:
+	var result: Array[CanvasItem] = []
+	if node is CanvasItem:
+		result.append(node)
+	for child in node.get_children():
+		result.append_array(_get_content_canvas_items(child))
+	return result
+
+
+func _update_clipping_gradient_rect() -> void:
+	if not _clipping_gradient_material: return
+	var viewport_size := get_viewport_rect().size
+	var canvas_transform := get_global_transform_with_canvas()
+	var top_left := canvas_transform * Vector2.ZERO
+	var bottom_right := canvas_transform * size
+	_clipping_gradient_material.set_shader_parameter(
+		"mask_rect",
+		Vector4(
+			top_left.x / max(1.0, viewport_size.x),
+			top_left.y / max(1.0, viewport_size.y),
+			bottom_right.x / max(1.0, viewport_size.x),
+			bottom_right.y / max(1.0, viewport_size.y)
+		)
+	)
+	_clipping_gradient_material.set_shader_parameter("viewport_size", viewport_size)
+
+
 ## Sets default mouse filter for SmoothScroll children to [constant Control.MOUSE_FILTER_PASS]. [br]
 ## Called when a [param node] is added to the tree.
 func _on_node_added(node: Node) -> void:
@@ -237,6 +351,8 @@ func _on_node_added(node: Node) -> void:
 			if not node.has_meta("_smooth_scroll_default_mouse_filter_set"):
 				node.mouse_filter = Control.MOUSE_FILTER_PASS
 				node.set_meta("_smooth_scroll_default_mouse_filter_set", true)
+		if clipping_gradient != 0 and clipping_gradient_size > 0.0:
+			_apply_clipping_gradient_materials()
 
 
 ## Called when the scrollbar hide timer times out. Hides scrollbars when neither scrollbar is being dragged.


### PR DESCRIPTION
Added both vertical and horizontal optional smooth alpha clipping of content inside scrollable container. I think it's definitely optional, and may be not a good fit, however, such clipping is the most common feature people usually need.

Also, I should mention, that partially this pull request was produced using Codex CLI, so it's up to you to merge it or not. :)

<img width="452" height="317" alt="image" src="https://github.com/user-attachments/assets/8210a64c-87f0-4137-9987-d8bc823083b4" />
